### PR TITLE
Few small things

### DIFF
--- a/dash_extensions/callback.py
+++ b/dash_extensions/callback.py
@@ -104,7 +104,7 @@ class CallbackCache(CallbackBlueprint):
 
     """
 
-    def __init__(self, cache=None, session_check=None, instant_refresh=None):
+    def __init__(self, cache=None, session_check=True, instant_refresh=True):
         super().__init__()
         if cache is not None:
             cache.default_timeout = 0  # the default_timeout of the inner cache is ignore

--- a/dash_extensions/callback.py
+++ b/dash_extensions/callback.py
@@ -71,7 +71,7 @@ def _register_callback(dash_app, callback):
 def _as_list(item):
     if item is None:
         return []
-    return item if isinstance(item, list) else [item]
+    return item if isinstance(item, list) else list(item)
 
 
 def _create_callback_id(item):

--- a/dash_extensions/callback.py
+++ b/dash_extensions/callback.py
@@ -99,6 +99,7 @@ class CallbackCache(CallbackBlueprint):
     since the values are typically stored as pickles, they do not need to be serialized to/from JSON.
 
     :param cache: cache backend, see https://flask-caching.readthedocs.io/en/latest/#built-in-cache-backends.
+            If None, uses FileSystemCache("cache", default_timeout=0).
     :param session_check: if True, the values will be stored uniquely per session
     :param instant_refresh: if True, callbacks will be evaluated every time, otherwise only when args change
 


### PR DESCRIPTION
Just some small things I edited while was reading the code

1) If tuple (or a generator) is ever passed to `_as_list` , the behaviour will not be what is wanted (it would be iterable inside a list). Not sure if this can ever happen, but maybe better change it still?

2) Added the default `cache` also in the documentation

3) Made the default values for `session_check` and `instant_refresh` since if `None`, they will be set to `True` later on. It makes the `help(function`)` easier to read.