### PR TITLE
Support for named parameters on callback annotation.

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -29,12 +29,28 @@ class DashTransformer(dash.Dash):
         for transform in self.transforms:
             transform.init(self)
 
+    @staticmethod
+    def extract_list_from_kwargs(kwargs: dict, key: str) -> list:
+        if kwargs is not None and key in kwargs:
+            contents = kwargs.pop(key)
+            if contents is None:
+                return []
+            if isinstance(contents, list):
+                return contents
+            else:
+                return [contents]
+        else:
+            return []
+
     def callback(self, *args, **kwargs):
         """
          This method saves the callbacks on the DashTransformer object. It acts as a proxy for the Dash app callback.
         """
         # Parse Output/Input/State (could be made simpler by enforcing input structure)
         multi_output = False
+        args = list(args) + DashTransformer.extract_list_from_kwargs(kwargs, 'output') + \
+               DashTransformer.extract_list_from_kwargs(kwargs, 'inputs') + \
+               DashTransformer.extract_list_from_kwargs(kwargs, 'state')
         callback = {arg_type: [] for arg_type in self.arg_types}
         arg_order = []
         for arg in args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dash
-more_itertools
+more-itertools
 pyyaml
 Flask-Caching
+requests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@
 # pip install -r requirements.txt
 
 dash[dev,testing]>=1.3.1
+selenium


### PR DESCRIPTION
Related to issue #13 

And other minor things unrelated to the issue itself that may or may not make any difference overall.
requirements:

- more_itertools -> more-itertools      (don't know if this makes a difference depending on which way you are using pip/conda or which IDE, but using PyCharm Community+Pip/Conda this made it work)
- and when I tried executing the package 'tests', it reported missing the following modules:
- requests	
- selenium