### PR TITLE
Serverside output example fix

### DIFF
--- a/examples/callback_serverside_output.py
+++ b/examples/callback_serverside_output.py
@@ -12,7 +12,7 @@ app.layout = html.Div([
 
 
 @app.callback(ServersideOutput("store", "data"), Input("btn", "n_clicks"))
-def query_data():
+def query_data(n_clicks):
     time.sleep(1)
     return px.data.gapminder()  # no JSON serialization here
 

--- a/examples/callback_serverside_output.py
+++ b/examples/callback_serverside_output.py
@@ -2,7 +2,7 @@ import time
 import dash_core_components as dcc
 import dash_html_components as html
 import plotly.express as px
-from dash_extensions.enrich import Dash, Output, Input, ServersideOutput
+from dash_extensions.enrich import Dash, Output, Input, State, ServersideOutput
 
 app = Dash(prevent_initial_callbacks=True)
 app.layout = html.Div([
@@ -22,8 +22,8 @@ def update_dd(df):
     return [{"label": column, "value": column} for column in df["year"]]  # no JSON de-serialization here
 
 
-@app.callback(Output("graph", "figure"), [Input("store", "data"), Input("dd", "value")])
-def update_graph(df, value):
+@app.callback(Output("graph", "figure"), [Input("dd", "value"), State("store", "data")])
+def update_graph(value, df):
     df = df.query("year == {}".format(value))  # no JSON de-serialization here
     return px.sunburst(df, path=['continent', 'country'], values='pop', color='lifeExp', hover_data=['iso_alpha'])
 

--- a/examples/callback_serverside_output.py
+++ b/examples/callback_serverside_output.py
@@ -2,7 +2,7 @@ import time
 import dash_core_components as dcc
 import dash_html_components as html
 import plotly.express as px
-from dash_extensions.enrich import Dash, Output, Input, Trigger, ServersideOutput
+from dash_extensions.enrich import Dash, Output, Input, ServersideOutput
 
 app = Dash(prevent_initial_callbacks=True)
 app.layout = html.Div([
@@ -11,7 +11,7 @@ app.layout = html.Div([
 ])
 
 
-@app.callback(ServersideOutput("store", "data"), Trigger("btn", "n_clicks"))
+@app.callback(ServersideOutput("store", "data"), Input("btn", "n_clicks"))
 def query_data():
     time.sleep(1)
     return px.data.gapminder()  # no JSON serialization here


### PR DESCRIPTION
The `examples/callback_serverside_output.py` had a few issues that wouldn't run. They are fixed. Tested the sample app with the latest version of the repo.