### PR TITLE
Prevent initial calls from intermediate stores

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -310,7 +310,7 @@ class MultiplexerTransform(DashTransform):
             function(){
                 return dash_clientside.callback_context.triggered[0].value;
             }
-        """, output, inputs)
+        """, output, inputs, prevent_initial_call=True)
 
 
 # endregion


### PR DESCRIPTION
The multiplexing transform creates a (client-side) callback function that updates an output from multiple intermediate stores. This callback should have the property `prevent_initial_call` set to `True` since it doesn't make sense to initialize the output from several stores at once (and only the first of the triggered ones are used anyway). This makes it possible to set `prevent_initial_call=True` in the user-defined callback functions, like this:

`@app.callback(
    Output(OUTPUT_ID, 'value'),
    Input(FIRST_INPUT_ID, 'n_clicks'),
    prevent_initial_call=True)
def f(_):
    return "Foo"

@app.callback(
    Output(OUTPUT_ID, 'value'),
    Input(SECOND_INPUT_ID, 'n_clicks'),
    prevent_initial_call=True)
def g(_):
    return "Bar"`

Before this change, the above example resulted in a javascript error saying that `dash_clientside.callback_context.triggered[0]` didn't have any value.