### PR TITLE
respect url_base_pathname

### DIFF
--- a/dash_extensions/websockets.py
+++ b/dash_extensions/websockets.py
@@ -1,8 +1,11 @@
-import uuid
 import json
 import secrets
-from flask_sockets import Sockets
+import urllib.parse
+import uuid
+
 from flask import session
+from flask_sockets import Sockets
+
 
 
 def ensure_session_id():
@@ -29,7 +32,7 @@ class SocketPool:
         self.sockets = Sockets(app.server)
         self.pool = {}
         # Add endpoint.
-        add_ws_endpoint(self.sockets, self.pool, handler, endpoint)
+        add_ws_endpoint(self.sockets, self.pool, handler, urllib.parse.urljoin(app.config.url_base_pathname, endpoint.strip("/")))
 
     def send(self, message):
         self._try_send(message, session["socket_id"])

--- a/src/lib/components/WebSocket.react.js
+++ b/src/lib/components/WebSocket.react.js
@@ -10,7 +10,7 @@ export default class DashWebSocket extends Component {
         // Create a new client.
         let {url} = this.props;
         const {protocols} = this.props;
-        url = url? url : "ws://" + location.host + "/ws";
+        url = url? url : "ws://" + location.host + location.pathname + "ws";
         this.client = new WebSocket(url, protocols);
         // Listen for events.
         this.client.onopen = (e) => {


### PR DESCRIPTION
Dash allows setting `url_base_pathname` to have multiple dash applications running on the same domain. However both the SocketPool and the Websocket component ignore this setting. This pull request aims to rectify this problem by having the SocketPool prepending the `url_base_pathname` to the path and the Websocket component also using `location.pathname` as a prefix since it does not have access to the configuration.