### PR TITLE
Remove redundant import `dash_html_components`

### DIFF
--- a/dash_extensions/snippets.py
+++ b/dash_extensions/snippets.py
@@ -3,7 +3,6 @@ import json
 import ntpath
 import base64
 import uuid
-import dash_html_components as html
 
 from dash import html, Output, Input, callback_context
 


### PR DESCRIPTION
Fix for UserWarning due to `dash_html_components` import

```python
/Users/username/project/.venv/lib/python3.9/site-packages/dash_extensions/snippets.py:7:  UserWarning: The dash_html_components package is deprecated. Please replace `import dash_html_components as html` with `from dash import html`
```