### PR TITLE
Adding the BlockingCallbackTransform to the default Dash object.

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -1009,6 +1009,7 @@ class Dash(DashProxy):
             LogTransform(),
             MultiplexerTransform(),
             NoOutputTransform(),
+            BlockingCallbackTransform(),
             ServersideOutputTransform(**output_defaults),
         ]
         super().__init__(*args, transforms=transforms, **kwargs)


### PR DESCRIPTION
The documentation specifies that:

> The enrich module also exposes a Dash object, which is a DashProxy object with **all** transformations loaded (...)

But in the current version, the `BlockingCallbackTransform` is not included in that list.

