### PR TITLE
Invoking blocked callbacks after the current invocation ends.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Makes it possible to avoid invoking a callback _if it is already running_. A typ
 
 Under the hood, hidden dummy elements (client side) and client side callbacks keep track of whether a callback is already running or not. If it is already running, the Python callback invocation is skipped.
 
+If one or more callback invocation is skipped, the callback will be invoked again automatically, just after the current invocation ends, using the latest values of input parameters.
+
 ## Multipage
 
 The `multipage` module makes it easy to create multipage apps. Pages can be constructed explicitly with the following syntax,
@@ -705,4 +707,36 @@ def sync_inputs(data):
 
 if __name__ == '__main__':
     app.run_server(debug=False)
+```
+
+### ForwardStore
+
+The `ForwardStore` component is a simple data store that automatically copies the current value of the sourceData property into the destinationData property. It can be used to break circular dependencies.
+
+```python
+import time
+from dash import Dash, Input, Output, html
+from dash_extensions.enrich import ForwardStore
+
+app = Dash(__name__)
+server = app.server
+app.layout = html.Div([
+    html.Div(id="output"),
+    ForwardStore(id="store", destinationData=10)
+])
+
+
+@app.callback(Output("output", "children"), Input("store", "destinationData"))
+def update_output(value):
+    return f"Current value: {value}"
+
+
+@app.callback(Output("store", "sourceData"), Input("store", "destinationData"))
+def calculate(value):
+    time.sleep(1)
+    return value + 1
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)
 ```

--- a/dash_extensions/_imports_.py
+++ b/dash_extensions/_imports_.py
@@ -4,6 +4,7 @@ from .DeferScript import DeferScript
 from .Download import Download
 from .EventListener import EventListener
 from .EventSource import EventSource
+from .ForwardStore import ForwardStore
 from .Keyboard import Keyboard
 from .Lottie import Lottie
 from .Mermaid import Mermaid
@@ -19,6 +20,7 @@ __all__ = [
     "Download",
     "EventListener",
     "EventSource",
+    "ForwardStore",
     "Keyboard",
     "Lottie",
     "Mermaid",

--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -36,6 +36,7 @@ from flask_caching.backends import FileSystemCache, RedisCache
 from more_itertools import flatten
 from collections import defaultdict
 from typing import Dict, Callable, List
+from .ForwardStore import ForwardStore
 
 _wildcard_mappings = {ALL: "<ALL>", MATCH: "<MATCH>", ALLSMALLER: "<ALLSMALLER>"}
 _wildcard_values = list(_wildcard_mappings.values())
@@ -286,9 +287,15 @@ class BlockingCallbackTransform(DashTransform):
             start_client_id = f"{callback_id}_start_client"
             end_server_id = f"{callback_id}_end_server"
             end_client_id = f"{callback_id}_end_client"
-            self.components.extend(
-                [dcc.Store(id=start_client_id), dcc.Store(id=end_server_id), dcc.Store(id=end_client_id)]
-            )
+            start_blocked_id = f"{callback_id}_start_blocked"
+            end_blocked_id = f"{callback_id}_end_blocked"
+            self.components.extend([
+                dcc.Store(id=start_client_id),
+                dcc.Store(id=end_server_id),
+                dcc.Store(id=end_client_id),
+                dcc.Store(id=start_blocked_id),
+                ForwardStore(id=end_blocked_id)
+            ])
             # Bind start signal callback.
             start_callback = f"""function()
             {{
@@ -296,29 +303,41 @@ class BlockingCallbackTransform(DashTransform):
                 const end = arguments[arguments.length-1];
                 const now = new Date().getTime();
                 if(!end & !start){{
-                    return now;
+                    return [now, null];
                 }}
-                if((now - start)/1000 > {timeout}){{              
-                    console.log("HITTING TIMEOUT");  
-                    return now;
+                if((now - start)/1000 > {timeout}){{
+                    // timed out
+                    return [now, null];
                 }}
                 if(!end){{
-                    return window.dash_clientside.no_update;
+                    // blocked
+                    return [window.dash_clientside.no_update, now];
                 }}
                 if(end > start){{
-                    return now;
+                    return [now, null];
                 }}
-                return window.dash_clientside.no_update;
+                return [window.dash_clientside.no_update, now];
             }}"""
             self.app.clientside_callback(
                 start_callback,
-                Output(start_client_id, "data"),
-                callback[Input],
+                [Output(start_client_id, "data"), Output(start_blocked_id, "data")],
+                callback[Input] + [Input(end_blocked_id, "destinationData")],
                 [State(start_client_id, "data"), State(end_client_id, "data")],
             )
             # Bind end signal callback.
+            end_callback = """function(endServerId, startBlockedId)
+            {
+                const now = new Date().getTime();
+                if(startBlockedId){
+                    return [now, now];
+                }
+                return [now, window.dash_clientside.no_update];
+            }"""
             self.app.clientside_callback(
-                "function(){return new Date().getTime();}", Output(end_client_id, "data"), Input(end_server_id, "data")
+                end_callback,
+                [Output(end_client_id, "data"), Output(end_blocked_id, "sourceData")],
+                Input(end_server_id, "data"),
+                State(start_blocked_id, "data")
             )
             # Modify the original callback to send finished signal.
             callback[Output].append(Output(end_server_id, "data"))

--- a/src/lib/components/ForwardStore.react.js
+++ b/src/lib/components/ForwardStore.react.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/** Simple data store that automatically copies the current value of the sourceData property into destinationData property. Can be used to break circular dependencies. */
+export default class ForwardStore extends React.Component {
+  componentDidUpdate() {
+    if (this.props.hasOwnProperty('sourceData'))
+      this.props.setProps({destinationData: this.props.sourceData});
+  }
+
+  render() {
+    return null;
+  }
+}
+
+ForwardStore.defaultProps = {
+};
+
+ForwardStore.propTypes = {
+  /**
+  * The ID used to identify this component in Dash callbacks.
+  */
+  id: PropTypes.string,
+
+  /**
+  * Shoud be used to set the new value of the forwarded data.
+  */
+  sourceData: PropTypes.any,
+
+  /**
+  * Shoud be used to read the forwarded value.
+  */
+  destinationData: PropTypes.any,
+
+  /**
+  * Dash-assigned callback that should be called to report property changes
+  * to Dash, to make them available for callbacks.
+  */
+  setProps: PropTypes.func
+
+};

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -12,6 +12,7 @@ import DeferScript from "./components/DeferScript.react";
 import Purify from "./components/Purify.react";
 import EventListener from "./components/EventListener.react";
 import EventSource from "./components/EventSource.react";
+import ForwardStore from "./components/ForwardStore.react";
 
 export {
     Download,
@@ -27,4 +28,5 @@ export {
     Purify,
     EventListener,
     EventSource,
+    ForwardStore,
 };


### PR DESCRIPTION
In this PR I change the `BlockingCallbackTransform`, so that:
> If one or more callback invocation is skipped, the callback will be invoked again automatically, just after the current invocation ends, using the latest values of input parameters.

-----

Example:

Let's take a look at the following code:
```python
app = Dash(__name__)
app.layout = html.Div([
    dcc.Input(id="input", value=""),
    html.Div(id="output"),
])

@app.callback(Output("output", "children"), Input("input", "value"), blocking=False)
def display_output(value):
    print(f"Server value: {value}")
    time.sleep(2)
    return f"Client value: {value}"
```

It performs a relatively "expensive" operation on the server and displays its result in the user interface.

As the `blocking` property is set to `False`, it will NOT be using the `BlockingCallbackTransform`.

Because of this, if a user types into the `input` text box `1234` relatively quickly, the server will print:
```
Server value:
Server value: 1
Server value: 12
Server value: 123
Server value: 1234
```
And the user will see:
```
Client value:
Client value: 1234
```

In addition, if the user writes a relatively long sentence without pausing, he/she will not see any of the intermediate results (despite them being calculated).

Now if we set the `blocking` to `True`, the perceived behavior will change.

The server will print:
```
Server value:
Server value: 1
```
And the user will see:
```
Client value:
Client value: 1
```

That's because the `BlockingCallbackTransform` will block all callback invocations that happen within 2 seconds of the first key stroke. Thanks to this the server doesn't have to perform redundant expensive calculations, but (as presented) it can lead to unexpected behaviors (as the user clearly sees that the textbox contains `1234` in it, while, even after 10 seconds, the output still displays `Client value: 1`).

The proposed change guarantees that the callback is invoked one last time, after the current invocation ends, to guarantee that the produced output value takes into account the latest state of the input.

The server will now print:
```
Server value:
Server value: 1
Server value: 1234
```
And the user will see:
```
Client value:
Client value: 1
Client value: 1234
```

As you can see, the calculations for input `12` and `123` were skipped (saving the server resources), but the user still receives the correct result of the final calculation.

This change also preserves the desired behavior of the UI still refreshing when using an interval that is shorter than the callback calculation time (with a difference that invocations will occur one after the other instead of waiting for the next tick of the `Interval`).

-----

To achieve this behavior, I also had to create the `ForwardStore` component.

> The `ForwardStore` component is a simple data store that automatically copies the current value of the sourceData property into the destinationData property. It can be used to break circular dependencies.

It helps in breaking a circular dependency between an input of the callback that invokes the user defined code and an output of the callback that is trigger after it finishes. 

-----

I hope this change is in line with your vision for the `BlockingCallbackTransform`.
Thanks! 