### PR TITLE
Add cycle breaker transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.1] - NOT RELEASED
 
+### Added
+
+- Added `CycleBreaker` component, contributed by  @TomaszRewak
+- Added `CycleBreakerTransform` transform
+
 ### Changed
 
 - Bug when a single output of list type was used with `LogTransform` and `BlockingCallbackTransform` fixed by @TomaszRewak

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 * Go through PRs
 * Add flexible callback signatures
 * Look into long callback support
+* PreventUpdateTransform

--- a/dash_extensions/_imports_.py
+++ b/dash_extensions/_imports_.py
@@ -1,4 +1,5 @@
 from .BeforeAfter import BeforeAfter
+from .CycleBreaker import CycleBreaker
 from .DeferScript import DeferScript
 from .EventListener import EventListener
 from .EventSource import EventSource
@@ -10,6 +11,7 @@ from .WebSocket import WebSocket
 
 __all__ = [
     "BeforeAfter",
+    "CycleBreaker",
     "DeferScript",
     "EventListener",
     "EventSource",

--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -567,7 +567,7 @@ class CycleBreakerTransform(DashTransform):
         # Update inputs.
         for c in callbacks + clientside_callbacks:
             for i in c.inputs:
-                if isinstance(c, Input) and c.break_cycle:
+                if isinstance(i, Input) and i.break_cycle:
                     cid = self._cycle_break_id(i)
                     cycle_inputs[cid] = (i.component_id, i.component_property)
                     i.component_id = cid

--- a/src/lib/components/CycleBreaker.react.js
+++ b/src/lib/components/CycleBreaker.react.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/** Simple data store that automatically copies the current value of the src property into dst property. Can be used to break circular dependencies. */
+export default class CycleBreaker extends React.Component {
+  componentDidUpdate() {
+    if (this.props.hasOwnProperty('src')){
+      this.props.setProps({dst: this.props.src});
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+CycleBreaker.defaultProps = {
+};
+
+CycleBreaker.propTypes = {
+  /**
+  * The ID used to identify this component in Dash callbacks.
+  */
+  id: PropTypes.string,
+
+  /**
+  * Set this property to value to be forwarded from .
+  */
+  src: PropTypes.any,
+
+  /**
+  * Read the forwarded value from this property.
+  */
+  dst: PropTypes.any,
+
+  /**
+  * Dash-assigned callback that should be called to report property changes
+  * to Dash, to make them available for callbacks.
+  */
+  setProps: PropTypes.func
+
+};

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,7 @@ import DeferScript from "./components/DeferScript.react";
 import Purify from "./components/Purify.react";
 import EventListener from "./components/EventListener.react";
 import EventSource from "./components/EventSource.react";
+import CycleBreaker from "./components/CycleBreaker.react";
 
 export {
     Lottie,
@@ -18,5 +19,6 @@ export {
     DeferScript,
     Purify,
     EventListener,
-    EventSource
+    EventSource,
+    CycleBreaker
 };

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,9 +1,10 @@
 import time
 import pandas as pd
+from dash.exceptions import PreventUpdate
 
 from dash_extensions.enrich import Output, Input, State, CallbackBlueprint, html, DashProxy, NoOutputTransform, Trigger, \
     TriggerTransform, MultiplexerTransform, PrefixIdTransform, callback, clientside_callback, DashLogger, LogTransform, \
-    BlockingCallbackTransform, dcc, ServersideOutputTransform, ServersideOutput, ALL
+    BlockingCallbackTransform, dcc, ServersideOutputTransform, ServersideOutput, ALL, CycleBreakerTransform
 
 
 # region Test utils/stubs
@@ -323,3 +324,32 @@ def test_log_transform(dash_duo):
     _basic_dash_proxy_test(dash_duo, app, ["log_server"])
     # Check that log is written to div element.
     assert dash_duo.find_element("#log").text == "INFO: info\nWARNING: warning\nERROR: error"
+
+
+def test_cycle_breaker_transform(dash_duo):
+    cycle_breaks = [("fahrenheit", "value")]
+    app = DashProxy(transforms=[CycleBreakerTransform(cycle_breaks=cycle_breaks)])
+    app.layout = html.Div([
+        dcc.Input(id="celsius", label="Celsius"),
+        dcc.Input(id="fahrenheit", label="Fahrenheit"),
+    ])
+
+    @app.callback(Output("celsius", "value"), Input("fahrenheit", "value"))
+    def update_celsius(value):
+        if value is None:
+            raise PreventUpdate()
+        return (float(value) - 32) / 9 * 5
+
+    @app.callback(Output("fahrenheit", "value"), Input("celsius", "value"))
+    def update_fahrenheit(value):
+        if value is None:
+            raise PreventUpdate()
+        return float(value) / 5 * 9 + 32
+
+    dash_duo.start_server(app)
+    f = dash_duo.find_element("#fahrenheit")
+    f.send_keys("32")
+    dash_duo.wait_for_text_to_equal("#celsius", "0")
+    c = dash_duo.find_element("#celcius")
+    c.send_keys("100")
+    dash_duo.wait_for_text_to_equal("#fahrenheit", "212")


### PR DESCRIPTION
Add `CycleBreaker` component and associated `CycleBreakerTransform`. The following code,

```
import dash_mantine_components as dmc
from dash.exceptions import PreventUpdate
from enrich import DashProxy, html, Output, Input

app = DashProxy()
app.layout = html.Div([
    dmc.NumberInput(id="celsius", label="Celsius"),
    dmc.NumberInput(id="fahrenheit", label="Fahrenheit"),
])


@app.callback(Output("celsius", "value"), Input("fahrenheit", "value"))
def update_celsius(value):
    if value is None:
        raise PreventUpdate()
    return (float(value) - 32) / 9 * 5


@app.callback(Output("fahrenheit", "value"), Input("celsius", "value"))
def update_fahrenheit(value):
    if value is None:
        raise PreventUpdate()
    return float(value) / 5 * 9 + 32


if __name__ == '__main__':
    app.run_server()

```

raises a error like,

`"Error: Dependency Cycle Found: celsius.value -> fahrenheit.value -> celsius.value"`

The new transform makes it possible to remove the error simply by mounting the transform with a specification on where to break the cycle,

```
import dash_mantine_components as dmc
from dash.exceptions import PreventUpdate
from enrich import DashProxy, html, Output, Input, CycleBreakerTransform

cycle_breaks = [("fahrenheit", "value")]
app = DashProxy(transforms=[CycleBreakerTransform(cycle_breaks=cycle_breaks)])
app.layout = html.Div([
    dmc.NumberInput(id="celsius", label="Celsius"),
    dmc.NumberInput(id="fahrenheit", label="Fahrenheit"),
])


@app.callback(Output("celsius", "value"), Input("fahrenheit", "value"))
def update_celsius(value):
    if value is None:
        raise PreventUpdate()
    return (float(value) - 32) / 9 * 5


@app.callback(Output("fahrenheit", "value"), Input("celsius", "value"))
def update_fahrenheit(value):
    if value is None:
        raise PreventUpdate()
    return float(value) / 5 * 9 + 32


if __name__ == '__main__':
    app.run_server()
```