### PR TITLE
Fix ServersideOutput to work with background callback

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,3 +38,9 @@ jobs:
         poetry run npm run build_no_r
         poetry build
         poetry publish --username=${{ secrets.PYPI_USERNAME }} --password=${{ secrets.PYPI_PASSWORD }}
+    - name: publish-to-conda
+      uses: fcakyon/conda-publish-action@v1.3
+      with:
+        subdir: 'conda'
+        anacondatoken: ${{ secrets.ANACONDA_TOKEN }}
+        platforms: 'win osx linux'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,6 +17,10 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12
+    - name: GitHub Tag Name example
+      run: |
+        echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+        echo "Tag name from github.ref_name: ${{  github.ref_name }}"
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/conda/meta.yml
+++ b/conda/meta.yml
@@ -1,0 +1,27 @@
+{% set version = "0.1.5" %}
+
+package:
+  name: "dash-extensions"
+  version: {{ version }}
+
+#source:
+#  url: <URL-of-the-source-distribution-of-my-package-on-PyPI>.tar.gz
+#  sha256: <SHA256-of-the-source-distribution-of-my-package-on-PyPI>
+
+build:
+  noarch: python
+  script: python -m pip install .
+
+requirements:
+  host:
+    - python
+    - pip
+    - poetry
+  run:
+    - python
+
+about:
+  license: MIT
+  license_familY: MIT
+  license_file: LICENSE
+  summary: "Extensions for Plotly Dash."

--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -1168,7 +1168,10 @@ def _pack_outputs(callback):
                 if serverside_output or memoize:
                     # Filter out Triggers (a little ugly to do here, should ideally be handled elsewhere).
                     is_trigger = [isinstance(item, Trigger) for item in callback.inputs]
-                    filtered_args = [arg for i, arg in enumerate(args) if not is_trigger[i]]
+                    if callback.kwargs.get("progress") is None:
+                        filtered_args = [arg for i, arg in enumerate(args) if not is_trigger[i]]
+                    else:
+                        filtered_args = [arg for i, arg in enumerate(args[1:]) if not is_trigger[i]]
                     unique_id = _get_cache_id(f, output, list(filtered_args), output.session_check, output.arg_check)
                     output.backend.set(unique_id, data[i])
                     # Replace only for server side outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dash-extensions"
-version = "0.1.5"
+version = "0.1.6rc1"
 description = "Extensions for Plotly Dash."
 authors = ["emher <emil.h.eriksen@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
When a @dash.callback decorator has a progress argument (in conjunction
with background argument), it expects an additional argument at the
beginning of the cakkback function signature. This additional argument
confuses serverside output transformation. This PR tries to address that (see issue #205 ).