### PR TITLE
fix: constrain dash-mantine-components version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ dash = ">=2.7.0"
 more-itertools = "^8.12.0"
 jsbeautifier = "^1.14.3"
 Flask-Caching = "2.0.1"
+dash-mantine-components = {version = "^0.10,<0.11", optional = true}
+
+[tool.poetry.extras]
+mantine = ["dash-mantine-components"]
 
 [tool.poetry.dev-dependencies]
 dash = {extras = ["dev", "testing"], version = "^2.7.0"}


### PR DESCRIPTION
Version 0.11 of dash-mantine-components no longer accepts an `id` prop for the NotificationsProvider. This constrains the version so that downstream projects using poetry can be prevented from using the incompatible version.

1. An alternative approach would be to update the code to support the new mantine version. Making it backwards compatible would require more investigation.
2. I'm not sure why dmc 0.11 no longer accepts an ID for the provider (presumably because the provider must be a singleton anyway?)
3. Regardless of approach, I reccommend still adding dmc as an optional dependency that's selectable as an extra to tht downstream projects benefit from version constraints.