### PR TITLE
DashBlueprint layout accepts args and kwargs

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -314,8 +314,8 @@ class DashBlueprint:
         self.clientside_callbacks = []
         self.transforms = []
 
-    def _layout_value(self):
-        layout = self._layout() if self._layout_is_function else self._layout
+    def _layout_value(self, *args, **kwargs):
+        layout = self._layout(*args, **kwargs) if self._layout_is_function else self._layout
         for transform in self.transforms:
             layout = transform.layout(layout, self._layout_is_function)
         return layout


### PR DESCRIPTION
Let the layout function for DashBlueprint accept variable number arguments and keyword arguments. This will let the layout of a DashBlueprint to accept query parameters as keyword arguments.

Fixes #250