### PR TITLE
Fix `_Wildcard` import error by using new public `Wildcard` class

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -45,7 +45,7 @@ from dash import (  # lgtm [py/unused-import]; noqa: F401
 )
 from dash._callback_context import context_value
 from dash._utils import patch_collections_abc
-from dash.dependencies import DashDependency, _Wildcard  # lgtm [py/unused-import]
+from dash.dependencies import DashDependency  # lgtm [py/unused-import]
 from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate
 from dataclass_wizard import asdict, fromdict
@@ -55,6 +55,13 @@ from pydantic import BaseModel  # type: ignore
 
 from dash_extensions import CycleBreaker
 from dash_extensions.utils import as_list
+
+try:
+    # Dash 3.4.0 moved _Wildcard to a public class. Try importing both before failing to support backwards compatibility
+    from dash.dependencies import Wildcard  # lgtm [py/unused-import]
+except ImportError:
+    from dash.dependencies import _Wildcard as Wildcard # lgtm [py/unused-import]
+
 
 T = TypeVar("T")
 
@@ -913,7 +920,7 @@ def apply_prefix(prefix, component_id, escape):
             if isinstance(component_id[key], int):
                 continue
             # This branch handles the wildcard callbacks.
-            if isinstance(component_id[key], _Wildcard):
+            if isinstance(component_id[key], Wildcard):
                 continue
             # All "normal" props are prefixed.
             component_id[key] = "{}-{}".format(prefix, component_id[key])


### PR DESCRIPTION
* Dash 3.4.0 moved _Wildcard to a public class. Try importing both before failing to support backwards compatibility